### PR TITLE
Improve mobile styles for group room

### DIFF
--- a/src/components/MemberPlateCounter.css
+++ b/src/components/MemberPlateCounter.css
@@ -15,7 +15,9 @@
 
 .sushi-plate {
   display: flex;
-  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--space-sm);
 }
 
 .sushi-plate__label {
@@ -25,10 +27,10 @@
 }
 
 .sushi-plate__counter {
-  width: 200px;
-  display: inline-flex;
-  padding-left: 20px;
-  gap: 30px;
+  display: flex;
+  flex: 1;
+  justify-content: flex-end;
+  gap: var(--space-sm);
 }
 
 .sushi-plate__counter--readonly {
@@ -47,7 +49,7 @@
   font-size: var(--font-size-md);
 }
 
-.sushi-pate__counter--plus {
+.sushi-plate__counter--plus {
   cursor: pointer;
   font-size: var(--font-size-md);
 }

--- a/src/routes/group/$roomId/(roomId)/index.css
+++ b/src/routes/group/$roomId/(roomId)/index.css
@@ -1,8 +1,9 @@
 .groupRoom {
   max-width: 720px;
-  margin: 32px auto;
-  padding: var(--space-lg);
+  margin: 0 auto;
+  padding: var(--space-lg) var(--space-md);
   border-radius: 16px;
+  width: 100%;
 }
 
 .header {
@@ -38,9 +39,15 @@
 
 .controls {
   display: grid;
-  grid-template-columns: repeat(2, 1fr);
+  grid-template-columns: 1fr;
   padding-bottom: 20px;
   gap: 0.5rem;
+}
+
+@media (min-width: 480px) {
+  .controls {
+    grid-template-columns: repeat(2, 1fr);
+  }
 }
 
 .switchUser {
@@ -63,6 +70,39 @@
   flex-direction: column;
   gap: 10px;
   margin-bottom: var(--space-lg);
+}
+
+.group-room__member-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+  margin-bottom: var(--space-lg);
+}
+
+.group-room__template-editor {
+  background-color: var(--color-surface-alt);
+  padding: var(--space-md);
+  border-radius: 8px;
+  margin-bottom: var(--space-lg);
+}
+
+.group-room__template-editor ul {
+  list-style: none;
+  padding: 0;
+  margin-bottom: var(--space-md);
+}
+
+.group-room__template-editor li {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: var(--space-xs) 0;
+}
+
+.group-room__template-editor input {
+  width: 100%;
+  padding: var(--space-xs);
+  margin-bottom: var(--space-xs);
 }
 
 .shareButton {
@@ -202,7 +242,7 @@
   z-index: 999;
 }
 
-.modalContent {
+.modal-content {
   background: white;
   padding: 2rem;
   border-radius: 8px;


### PR DESCRIPTION
## Summary
- adjust plate counter layout for small screens
- tweak group room layout and add responsive styles
- style template editor and member list containers
- fix modal class name and apply mobile-first controls layout

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687625db6ce083278b04751fe7866449