### PR TITLE
Remove redundant plate name input

### DIFF
--- a/src/routes/group/$roomId/(roomId)/components/BulkPlateModal.tsx
+++ b/src/routes/group/$roomId/(roomId)/components/BulkPlateModal.tsx
@@ -1,8 +1,6 @@
-type BulkEntry = {color: string; price: number};
-
 type Props = {
-  entries: BulkEntry[];
-  onChange: (entries: BulkEntry[]) => void;
+  entries: number[];
+  onChange: (entries: number[]) => void;
   onAddRow: () => void;
   onSave: () => void;
   onCancel: () => void;
@@ -19,32 +17,23 @@ export const BulkPlateModal = ({
     <div className="fixed inset-0 flex items-center justify-center bg-black/40">
       <div className="w-11/12 max-w-md p-6 bg-white rounded-lg shadow-lg">
         <h3 className="mb-2 text-lg font-bold">皿の一括登録</h3>
-        <p className="mb-4 text-sm text-gray-600">皿の名前と金額を入力してください。</p>
+        <p className="mb-4 text-sm text-gray-600">
+          皿の金額を入力してください。名前は自動で設定されます。
+        </p>
 
-        {entries.map((entry, index) => (
+        {entries.map((price, index) => (
           <div
             key={index}
             className="flex flex-col gap-2 mb-3 sm:flex-row"
           >
             <input
-              type="text"
-              placeholder="皿の名前"
-              className="flex-1 p-2 border rounded"
-              value={entry.color}
-              onChange={(e) => {
-                const updated = [...entries];
-                updated[index].color = e.target.value;
-                onChange(updated);
-              }}
-            />
-            <input
               type="number"
               placeholder="金額"
               className="flex-1 p-2 border rounded"
-              value={entry.price}
+              value={price}
               onChange={(e) => {
                 const updated = [...entries];
-                updated[index].price = Number(e.target.value);
+                updated[index] = Number(e.target.value);
                 onChange(updated);
               }}
             />

--- a/src/routes/group/$roomId/(roomId)/components/EditPlateModal.tsx
+++ b/src/routes/group/$roomId/(roomId)/components/EditPlateModal.tsx
@@ -1,32 +1,22 @@
 type Props = {
-  color: string;
   price: number;
-  onChange: (newColor: string, newPrice: number) => void;
+  onChange: (newPrice: number) => void;
   onSave: () => void;
   onCancel: () => void;
 };
 
 export const EditPlateModal = ({
-  color,
   price,
   onChange,
   onSave,
   onCancel,
 }: Props) => {
+  const color = `${price}円皿`;
   return (
     <div className="fixed inset-0 flex items-center justify-center bg-black/40">
       <div className="w-11/12 max-w-md p-6 bg-white rounded-lg shadow-lg">
         <h3 className="mb-4 text-lg font-bold">皿の情報を編集</h3>
-
-        <label className="flex flex-col mb-3 text-sm">
-          名前（皿の種類）:
-          <input
-            type="text"
-            className="w-full p-2 mt-1 border rounded"
-            value={color}
-            onChange={(e) => onChange(e.target.value, price)}
-          />
-        </label>
+        <p className="mb-3 text-sm">皿の名前: {color}</p>
 
         <label className="flex flex-col mb-3 text-sm">
           金額（円）:
@@ -34,7 +24,7 @@ export const EditPlateModal = ({
             type="number"
             className="w-full p-2 mt-1 border rounded"
             value={price}
-            onChange={(e) => onChange(color, Number(e.target.value))}
+            onChange={(e) => onChange(Number(e.target.value))}
           />
         </label>
 

--- a/src/routes/group/$roomId/(roomId)/components/PlateTemplateEditor.tsx
+++ b/src/routes/group/$roomId/(roomId)/components/PlateTemplateEditor.tsx
@@ -4,7 +4,7 @@ type Props = {
   template: {prices: Record<string, number>};
   onEdit: (color: string, price: number) => void;
   onRemove: (color: string) => void;
-  onAdd: (color: string, price: number) => void;
+  onAdd: (price: number) => void;
   onBulkClick: () => void;
 };
 
@@ -15,7 +15,6 @@ export const PlateTemplateEditor = ({
   onAdd,
   onBulkClick,
 }: Props) => {
-  const [newPlate, setNewPlate] = useState("");
   const [newPrice, setNewPrice] = useState(0);
 
   return (
@@ -43,12 +42,6 @@ export const PlateTemplateEditor = ({
 
       <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
         <input
-          placeholder="新しい皿"
-          className="flex-1 p-2 border rounded"
-          value={newPlate}
-          onChange={(e) => setNewPlate(e.target.value)}
-        />
-        <input
           placeholder="金額"
           type="number"
           className="flex-1 p-2 border rounded"
@@ -58,9 +51,8 @@ export const PlateTemplateEditor = ({
         <button
           className="px-3 py-1 text-white bg-teal-600 rounded"
           onClick={() => {
-            if (newPlate.trim() && newPrice > 0) {
-              onAdd(newPlate.trim(), newPrice);
-              setNewPlate("");
+            if (newPrice > 0) {
+              onAdd(newPrice);
               setNewPrice(0);
             }
           }}

--- a/src/routes/group/$roomId/(roomId)/index.tsx
+++ b/src/routes/group/$roomId/(roomId)/index.tsx
@@ -34,11 +34,11 @@ export function RouteComponent() {
 
   const [showRanking, setShowRanking] = useState(false);
   const [editingPlate, setEditingPlate] = useState<{
-    color: string;
+    originalColor: string;
     price: number;
   } | null>(null);
   const [showBulkModal, setShowBulkModal] = useState(false);
-  const [bulkEntries, setBulkEntries] = useState([{color: "", price: 0}]);
+  const [bulkEntries, setBulkEntries] = useState([0]);
 
   if (isLoading) return <p>読み込み中...</p>;
   if (error) return <p>エラーが発生しました: {(error as Error).message}</p>;
@@ -98,13 +98,16 @@ export function RouteComponent() {
         <div className="p-4 mb-6 bg-gray-100 rounded">
           <PlateTemplateEditor
             template={template}
-            onEdit={(color, price) => setEditingPlate({color, price})}
+            onEdit={(color, price) =>
+              setEditingPlate({originalColor: color, price})
+            }
             onRemove={(color) => {
               const updated = {...template.prices};
               delete updated[color];
               handleUpdateTemplate(updated);
             }}
-            onAdd={(color, price) => {
+            onAdd={(price) => {
+              const color = `${price}円皿`;
               const updated = {...template.prices, [color]: price};
               handleUpdateTemplate(updated);
             }}
@@ -134,16 +137,16 @@ export function RouteComponent() {
 
       {editingPlate && (
         <EditPlateModal
-          color={editingPlate.color}
           price={editingPlate.price}
-          onChange={(newColor, newPrice) =>
-            setEditingPlate({color: newColor, price: newPrice})
+          onChange={(newPrice) =>
+            setEditingPlate({...editingPlate, price: newPrice})
           }
           onSave={() => {
             const updated = {...template!.prices};
-            const oldColor = editingPlate.color;
+            const oldColor = editingPlate.originalColor;
+            const newColor = `${editingPlate.price}円皿`;
             delete updated[oldColor];
-            updated[editingPlate.color] = editingPlate.price;
+            updated[newColor] = editingPlate.price;
             handleUpdateTemplate(updated);
             setEditingPlate(null);
           }}
@@ -156,18 +159,19 @@ export function RouteComponent() {
           entries={bulkEntries}
           onChange={setBulkEntries}
           onAddRow={() =>
-            setBulkEntries([...bulkEntries, {color: "", price: 0}])
+            setBulkEntries([...bulkEntries, 0])
           }
           onSave={() => {
             const updated = {...template?.prices};
-            bulkEntries.forEach(({color, price}) => {
-              if (color.trim() && price > 0) {
-                updated[color.trim()] = price;
+            bulkEntries.forEach((price) => {
+              if (price > 0) {
+                const color = `${price}円皿`;
+                updated[color] = price;
               }
             });
             handleUpdateTemplate(updated);
             setShowBulkModal(false);
-            setBulkEntries([{color: "", price: 0}]);
+            setBulkEntries([0]);
           }}
           onCancel={() => setShowBulkModal(false)}
         />


### PR DESCRIPTION
## Summary
- Drop manual plate name entry and derive names from prices
- Simplify plate edit and bulk-add modals to accept only price
- Auto-generate plate labels like `120円皿` when adding or editing

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6891cc043c80832798b90d77697aae79